### PR TITLE
RDN-4545 Remove Helvetica font

### DIFF
--- a/css/storybook.scss
+++ b/css/storybook.scss
@@ -6,7 +6,7 @@ body {
 
 html {
   box-sizing: border-box;
-  font-family: Helvetica, "sans-serif";
+  font-family: "sans-serif";
   font-size: 14px;
 }
 


### PR DESCRIPTION
This should be pretty safe to remove. I've checked both Diary and Lite apps, both have overwrites for the < html > and lower level elements. On windows we don't have helvetica anyway, so even if it would be somehow used, it would have went to fallback font.